### PR TITLE
LIBITD-2295. Updated ingress example in README for K8S v1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,23 +259,31 @@ spec:
       - path: /favicon.ico
         pathType: Exact
         backend:
-          serviceName: foobar-static-files
-          servicePort: 80
+          service:
+           name: foobar-static-files
+           port:
+             number: 80
       - path: /googlee5878e862cad1cec.html
         pathType: Exact
         backend:
-          serviceName: foobar-static-files
-          servicePort: 80
+          service:
+            name: foobar-static-files
+            port:
+              number: 80
       - path: /robots.txt
         pathType: Exact
         backend:
-          serviceName: foobar-static-files
-          servicePort: 80
+          service:
+            name: foobar-static-files
+            port:
+              number: 80
       - path: /sitemap.xml
         pathType: Exact
         backend:
-          serviceName: foobar-static-files
-          servicePort: 80
+          service:
+            name: foobar-static-files
+            port:
+              number: 80
 #-----------------------------------------
 ```
 


### PR DESCRIPTION
Updated the ingress.yaml example in the README for changes necessary to work with Kubernetes 1.25.

Based on the changes made to "umd-lib/k8s-drum".

https://umd-dit.atlassian.net/browse/LIBITD-2295